### PR TITLE
Added a damage prevention config option for Charge Up.

### DIFF
--- a/JoeMod/Components/IBarrier.cs
+++ b/JoeMod/Components/IBarrier.cs
@@ -1,5 +1,0 @@
-﻿using RoR2;
-
-public interface IBarrier {
-    public void BlockedDamage(DamageInfo damageInfo, float actualDamageBlocked);
-}

--- a/JoeMod/Components/IReflectionBarrier.cs
+++ b/JoeMod/Components/IReflectionBarrier.cs
@@ -1,0 +1,5 @@
+﻿using RoR2;
+
+public interface IReflectionBarrier {
+    public void StoreDamage(DamageInfo damageInfo, float damageStored);
+}

--- a/JoeMod/Components/ZapBarrierController.cs
+++ b/JoeMod/Components/ZapBarrierController.cs
@@ -1,20 +1,19 @@
 ﻿using RoR2;
 using UnityEngine;
 
-public class ZapBarrierController : MonoBehaviour, IBarrier {
+public class ZapBarrierController : MonoBehaviour, IReflectionBarrier {
 
     private bool _recordingDamage;
     private float _recordedDamage;
-    public delegate void BlockedDamageEvent(float damageBlocked);
-    public BlockedDamageEvent onBlockedDamage;
-                                                     //I guess I would need IL for this
-    public void BlockedDamage(DamageInfo damageInfo, float actualDamageBlocked) {
-
+    
+    public delegate void StoredDamageEvent(float damageStored);
+    public StoredDamageEvent OnStoredDamage;
+    
+    public void StoreDamage(DamageInfo damageInfo, float damageStored) {
         if (_recordingDamage) {
-
-            _recordedDamage += actualDamageBlocked;
-            onBlockedDamage?.Invoke(actualDamageBlocked);
-            //Helpers.LogWarning("zap blocked " + actualDamageBlocked + "/" + _recordedDamage);
+            //Helpers.LogWarning("zap blocked " + damageStored + "/" + _recordedDamage);
+            OnStoredDamage?.Invoke(damageStored);
+            _recordedDamage += damageStored;
         }
     }
 
@@ -22,7 +21,7 @@ public class ZapBarrierController : MonoBehaviour, IBarrier {
         _recordingDamage = true;
     }
 
-    public float RedeemDamage() {
+    public float GetReflectedDamage() {
         float redeemed = _recordedDamage;
 
         _recordingDamage = false;

--- a/JoeMod/FacelessJoePlugin.cs
+++ b/JoeMod/FacelessJoePlugin.cs
@@ -100,19 +100,18 @@ public class FacelessJoePlugin : BaseUnityPlugin {
         bool flag = (damageInfo.damageType & DamageType.BypassArmor) > DamageType.Generic;
 
         if (self && self.body && self.body.HasBuff(Modules.Buffs.zapShieldBuff) && !flag) {
+            float mitigatedDamage = damageInfo.damage;
+            
             if (Modules.Config.UtilityDamageAbsorption >= 1.0f) {
                 damageInfo.rejected = true;
+            } else {
+                mitigatedDamage = (1.0f - Modules.Config.UtilityDamageAbsorption) * damageInfo.damage;
             }
 
-            //yes basically copied from the old barrier code
-            IBarrier bar = self.GetComponent<IBarrier>();
+            IReflectionBarrier bar = self.GetComponent<IReflectionBarrier>();
             if (bar != null) {
-                bar.BlockedDamage(damageInfo, damageInfo.damage); //I guess I would need IL for this
-            }
-
-            // Doing this after the other check just in case there is some weird event triggers from the above behavior.
-            if (!damageInfo.rejected) {
-                damageInfo.damage = (1.0f - Modules.Config.UtilityDamageAbsorption) * damageInfo.damage;
+                bar.StoreDamage(damageInfo, damageInfo.damage);
+                damageInfo.damage = mitigatedDamage;
             }
         }
         orig(self, damageInfo);

--- a/JoeMod/FacelessJoePlugin.cs
+++ b/JoeMod/FacelessJoePlugin.cs
@@ -36,7 +36,7 @@ using System.Security.Permissions;
 public class FacelessJoePlugin : BaseUnityPlugin {
     public const string MODUID = "com.TheTimeSweeper.TeslaTrooper";
     public const string MODNAME = "Tesla Trooper";
-    public const string MODVERSION = "1.1.2";
+    public const string MODVERSION = "1.1.3";
 
     // a prefix for name tokens to prevent conflicts- please capitalize all name tokens for convention
     public const string DEV_PREFIX = "HABIBI";
@@ -100,12 +100,19 @@ public class FacelessJoePlugin : BaseUnityPlugin {
         bool flag = (damageInfo.damageType & DamageType.BypassArmor) > DamageType.Generic;
 
         if (self && self.body && self.body.HasBuff(Modules.Buffs.zapShieldBuff) && !flag) {
-            damageInfo.rejected = true;
+            if (Modules.Config.UtilityDamageAbsorption >= 1.0f) {
+                damageInfo.rejected = true;
+            }
 
             //yes basically copied from the old barrier code
             IBarrier bar = self.GetComponent<IBarrier>();
-            if (bar!= null) {
+            if (bar != null) {
                 bar.BlockedDamage(damageInfo, damageInfo.damage); //I guess I would need IL for this
+            }
+
+            // Doing this after the other check just in case there is some weird event triggers from the above behavior.
+            if (!damageInfo.rejected) {
+                damageInfo.damage = (1.0f - Modules.Config.UtilityDamageAbsorption) * damageInfo.damage;
             }
         }
         orig(self, damageInfo);

--- a/JoeMod/Modules/Config.cs
+++ b/JoeMod/Modules/Config.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx.Configuration;
+﻿using System;
+using BepInEx.Configuration;
 using UnityEngine;
 
 namespace Modules
@@ -16,9 +17,8 @@ namespace Modules
 
         public static ConfigEntry<bool> TowerTargeting;
         public static int LysateLimit;
+        public static float UtilityDamageAbsorption;
         public static ConfigEntry<bool> UncappedUtility;
-
-
 
         public static void ReadConfig()
         {
@@ -79,10 +79,20 @@ namespace Modules
                 "Lysate Cell Additional Tower Limit",
                 1,
                 "With additional towers, lysate cell is way too strong for a green item. Default is 1, but for proper balance I would suggest 0\n-1 for unlimited. have fun").Value;
+            
+            UtilityDamageAbsorption = Clamp(
+                FacelessJoePlugin.instance.Config.Bind(
+                    sectionGameplay,
+                    "Utility Damage Absorption Cap",
+                    1.0f,
+                    "How much damage (as a percentage) is completely blocked while charging up. If set to 0, no damage would be blocked." +
+                    "\nNote that this does not affect how much damage is reflected after the buff expires.").Value,
+                0.0f,
+                1.0f);
 
             UncappedUtility = FacelessJoePlugin.instance.Config.Bind(
                 sectionGameplay,
-                "Uncapped utility damage",
+                "Uncapped Utility Damage",
                 false,
                 "Removes the cap on how much damage you can retaliate with.\nIf you want utility to be his main source of damage");
             
@@ -101,6 +111,16 @@ namespace Modules
         public static ConfigEntry<bool> EnemyEnableConfig(string characterName)
         {
             return FacelessJoePlugin.instance.Config.Bind<bool>(new ConfigDefinition(characterName, "Enabled"), true, new ConfigDescription("Set to false to disable this enemy"));
+        }
+        
+        public static T Clamp<T>(T val, T min, T max)
+            where T : IComparable<T>
+        {
+            if (val.CompareTo(min) < 0)
+                return min;
+            if(val.CompareTo(max) > 0)
+                return max;
+            return val;
         }
     }
 }

--- a/JoeMod/Modules/Config.cs
+++ b/JoeMod/Modules/Config.cs
@@ -92,11 +92,9 @@ namespace Modules
 
             UncappedUtility = FacelessJoePlugin.instance.Config.Bind(
                 sectionGameplay,
-                "Uncapped Utility Damage",
+                "Uncapped utility damage",
                 false,
                 "Removes the cap on how much damage you can retaliate with.\nIf you want utility to be his main source of damage");
-            
-
         }
 
         // this helper automatically makes config entries for disabling survivors

--- a/JoeMod/Modules/Config.cs
+++ b/JoeMod/Modules/Config.cs
@@ -80,7 +80,7 @@ namespace Modules
                 1,
                 "With additional towers, lysate cell is way too strong for a green item. Default is 1, but for proper balance I would suggest 0\n-1 for unlimited. have fun").Value;
             
-            UtilityDamageAbsorption = Clamp(
+            UtilityDamageAbsorption = Mathf.Clamp(
                 FacelessJoePlugin.instance.Config.Bind(
                     sectionGameplay,
                     "Utility Damage Absorption Cap",
@@ -109,16 +109,6 @@ namespace Modules
         public static ConfigEntry<bool> EnemyEnableConfig(string characterName)
         {
             return FacelessJoePlugin.instance.Config.Bind<bool>(new ConfigDefinition(characterName, "Enabled"), true, new ConfigDescription("Set to false to disable this enemy"));
-        }
-        
-        public static T Clamp<T>(T val, T min, T max)
-            where T : IComparable<T>
-        {
-            if (val.CompareTo(min) < 0)
-                return min;
-            if(val.CompareTo(max) > 0)
-                return max;
-            return val;
         }
     }
 }

--- a/JoeMod/Modules/Tokens.cs
+++ b/JoeMod/Modules/Tokens.cs
@@ -187,7 +187,12 @@ namespace Modules
 
             #region Utility
             LanguageAPI.Add(prefix + "UTILITY_BARRIER_NAME", "Charging Up");
-            LanguageAPI.Add(prefix + "UTILITY_BARRIER_DESCRIPTION", $"For {Helpers.UtilityText($"{ShieldZapCollectDamage.ShieldBuffDuration} seconds")}, {Helpers.UtilityText("all incoming damage")} taken is {Helpers.UtilityText("absorbed")}. After which, {Helpers.DamageText("blast")} in a wide area {Helpers.DamageText("based on damage absorbed")}.");
+            LanguageAPI.Add(prefix + "UTILITY_BARRIER_DESCRIPTION",
+                $"For {Helpers.UtilityText($"{ShieldZapCollectDamage.ShieldBuffDuration} seconds")}, " +
+                $"{Helpers.UtilityText("all incoming damage")} taken is {Helpers.UtilityText("stored")}, " +
+                $"and {Helpers.UtilityText(Config.UtilityDamageAbsorption * 100 + "% of that damage")} is negated completely. " +
+                $"After which, {Helpers.DamageText("blast")} in a wide area {Helpers.DamageText("based on damage stored")}.");
+
             #endregion
 
             #region Special

--- a/JoeMod/SkillStates/TeslaTrooper/Skills/ShieldZapReleaseDamage.cs
+++ b/JoeMod/SkillStates/TeslaTrooper/Skills/ShieldZapReleaseDamage.cs
@@ -38,7 +38,7 @@ namespace ModdedEntityStates.TeslaTrooper {
             float redeemedDamage = damageStat * 6.9f;
             ZapBarrierController controller = GetComponent<ZapBarrierController>();
             if (controller) {
-                redeemedDamage = controller.RedeemDamage();
+                redeemedDamage = controller.GetReflectedDamage();
             }
             
             float damageStatMultiplier = damageStat / characterBody.baseDamage;


### PR DESCRIPTION
Added a damage prevention config option for Charge Up. This will allow users to configure just how much damage is prevented from the ability.

I personally felt that this skill was just far too powerful with the current setup. Ideally I'd set it anywhere from 0 to 50% damage reduction, so I felt that a config option would be best.